### PR TITLE
I fixed some problems and made some enhancements to the tmLanguage file

### DIFF
--- a/RSpec.tmLanguage
+++ b/RSpec.tmLanguage
@@ -50,7 +50,7 @@
 	<array>
 		<dict>
 			<key>match</key>
-			<string>(?&lt;!\.)\b(before|after)\b(?![?!])</string>
+			<string>(?&lt;!\.)\b(before|after|subject|let)\b(?![?!])</string>
 			<key>name</key>
 			<string>keyword.other.rspec</string>
 		</dict>


### PR DESCRIPTION
The matching for pending examples (examples without blocks) was screwing up the highlighting of examples with blocks. That was bugging me so I fixed it.

Then I made some other easy enhancements while I was at it.

Now we have better RSpec syntax highlighting than TextMate people! :)  Actually, I'm going to find somebody with TextMate to test the changes I made then submit them to the official bundle.
