### PR TITLE
Align describe snippets with it snippets for consistency.

### DIFF
--- a/Snippets/Describe.tmSnippet
+++ b/Snippets/Describe.tmSnippet
@@ -4,7 +4,7 @@
 <dict>
 	<key>content</key>
 	<string>describe "${1:description}" do
-  it "should ${2:description}" do
+  it "${2:description}" do
     $0
   end
 end</string>

--- a/Snippets/Describe_type.tmSnippet
+++ b/Snippets/Describe_type.tmSnippet
@@ -4,7 +4,7 @@
 <dict>
 	<key>content</key>
 	<string>describe ${1:Type} do
-  it "should ${2:description}" do
+  it "${2:description}" do
     $0
   end
 end</string>

--- a/Snippets/Describe_type_string.tmSnippet
+++ b/Snippets/Describe_type_string.tmSnippet
@@ -4,7 +4,7 @@
 <dict>
 	<key>content</key>
 	<string>describe ${1:Type}, "${2:description}" do
-  it "should ${3:description}" do
+  it "${3:description}" do
     $0
   end
 end</string>


### PR DESCRIPTION
Removed `should` from `describe`-snippets.

Benefits:
- `Describe` snippets produce same `it` block as the `it` snippet.
- Supports both `it "should do something"` and `it "does something"` styles.
