### PR TITLE
Allow to jump to symbols inside a spec file

### DIFF
--- a/Preferences/SymbolList-Behaviour.tmPreferences
+++ b/Preferences/SymbolList-Behaviour.tmPreferences
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>name</key>
+	<string>Symbol List: Behaviour</string>
+	<key>scope</key>
+	<string>meta.rspec.behaviour</string>
+	<key>settings</key>
+	<dict>
+		<key>showInSymbolList</key>
+		<integer>1</integer>
+		<key>symbolTransformation</key>
+		<string>s/^\s*(describe)\s+(.+)\s+do\s*$/$2/</string>
+	</dict>
+	<key>uuid</key>
+	<string>28F89786-04F4-43D7-82A6-34B046C2BC6B</string>
+</dict>
+</plist>

--- a/Preferences/SymbolList-Example.tmPreferences
+++ b/Preferences/SymbolList-Example.tmPreferences
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>name</key>
+	<string>Symbol List: Example</string>
+	<key>scope</key>
+	<string>meta.rspec.example</string>
+	<key>settings</key>
+	<dict>
+		<key>showInSymbolList</key>
+		<integer>1</integer>
+		<key>symbolTransformation</key>
+		<string>s/^\s*(it)\s+(.+)\s+do\s*$/  $2/</string>
+	</dict>
+	<key>uuid</key>
+	<string>57EF6130-05A6-4117-94CB-C0BD63328334</string>
+</dict>
+</plist>

--- a/Preferences/SymbolList-Pending.tmPreferences
+++ b/Preferences/SymbolList-Pending.tmPreferences
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>name</key>
+	<string>Symbol List: Pending</string>
+	<key>scope</key>
+	<string>meta.rspec.pending</string>
+	<key>settings</key>
+	<dict>
+		<key>showInSymbolList</key>
+		<integer>1</integer>
+		<key>symbolTransformation</key>
+		<string>s/^\s*(it)\s+(.+)\s*$/  $2 (Pending)/</string>
+	</dict>
+	<key>uuid</key>
+	<string>377BD4F9-4321-4D14-9A34-6A93033F1906</string>
+</dict>
+</plist>


### PR DESCRIPTION
I copied the settings files from this repository: https://github.com/rspec/rspec-tmbundle
