### PR TITLE
FIX to not use double-quotes when not needed.

### DIFF
--- a/Snippets/Describe.tmSnippet
+++ b/Snippets/Describe.tmSnippet
@@ -2,19 +2,19 @@
 <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>content</key>
-	<string>describe "${1:description}" do
-  it "should ${2:description}" do
+  <key>content</key>
+  <string>describe '${1:description}' do
+  it 'should ${2:description}' do
     $0
   end
 end</string>
-	<key>name</key>
-	<string>describe (String)</string>
-	<key>scope</key>
-	<string>source.ruby.rspec</string>
-	<key>tabTrigger</key>
-	<string>des</string>
-	<key>uuid</key>
-	<string>34CBBD13-CE8E-4601-9968-C2CB0D771CA5</string>
+  <key>name</key>
+  <string>describe (String)</string>
+  <key>scope</key>
+  <string>source.ruby.rspec</string>
+  <key>tabTrigger</key>
+  <string>des</string>
+  <key>uuid</key>
+  <string>34CBBD13-CE8E-4601-9968-C2CB0D771CA5</string>
 </dict>
 </plist>

--- a/Snippets/Describe_type.tmSnippet
+++ b/Snippets/Describe_type.tmSnippet
@@ -2,19 +2,19 @@
 <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>content</key>
-	<string>describe ${1:Type} do
-  it "should ${2:description}" do
+  <key>content</key>
+  <string>describe ${1:Type} do
+  it 'should ${2:description}' do
     $0
   end
 end</string>
-	<key>name</key>
-	<string>describe (type)</string>
-	<key>scope</key>
-	<string>source.ruby.rspec</string>
-	<key>tabTrigger</key>
-	<string>dest</string>
-	<key>uuid</key>
-	<string>2ED94046-DAF7-4C91-8D98-771513BB3804</string>
+  <key>name</key>
+  <string>describe (type)</string>
+  <key>scope</key>
+  <string>source.ruby.rspec</string>
+  <key>tabTrigger</key>
+  <string>dest</string>
+  <key>uuid</key>
+  <string>2ED94046-DAF7-4C91-8D98-771513BB3804</string>
 </dict>
 </plist>

--- a/Snippets/Describe_type_string.tmSnippet
+++ b/Snippets/Describe_type_string.tmSnippet
@@ -2,19 +2,19 @@
 <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>content</key>
-	<string>describe ${1:Type}, "${2:description}" do
-  it "should ${3:description}" do
+  <key>content</key>
+  <string>describe ${1:Type}, '${2:description}' do
+  it 'should ${3:description}' do
     $0
   end
 end</string>
-	<key>name</key>
-	<string>describe (type, string)</string>
-	<key>scope</key>
-	<string>source.ruby.rspec</string>
-	<key>tabTrigger</key>
-	<string>dests</string>
-	<key>uuid</key>
-	<string>ACFE21E0-902B-45C4-BF54-D137718FF61C</string>
+  <key>name</key>
+  <string>describe (type, string)</string>
+  <key>scope</key>
+  <string>source.ruby.rspec</string>
+  <key>tabTrigger</key>
+  <string>dests</string>
+  <key>uuid</key>
+  <string>ACFE21E0-902B-45C4-BF54-D137718FF61C</string>
 </dict>
 </plist>

--- a/Snippets/It.tmSnippet
+++ b/Snippets/It.tmSnippet
@@ -2,17 +2,17 @@
 <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>content</key>
-	<string>it "${1:description}" do
+  <key>content</key>
+  <string>it '${1:description}' do
   $0
 end</string>
-	<key>name</key>
-	<string>it</string>
-	<key>scope</key>
-	<string>source.ruby.rspec</string>
-	<key>tabTrigger</key>
-	<string>it</string>
-	<key>uuid</key>
-	<string>AD51AA2B-09C9-40DE-9720-2FD43C967FA9</string>
+  <key>name</key>
+  <string>it</string>
+  <key>scope</key>
+  <string>source.ruby.rspec</string>
+  <key>tabTrigger</key>
+  <string>it</string>
+  <key>uuid</key>
+  <string>AD51AA2B-09C9-40DE-9720-2FD43C967FA9</string>
 </dict>
 </plist>

--- a/Snippets/Story.tmSnippet
+++ b/Snippets/Story.tmSnippet
@@ -2,20 +2,20 @@
 <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>content</key>
-	<string>Story "${1:title}", %{
+  <key>content</key>
+  <string>Story '${1:title}', %{
   As a${2:role}
   I want ${3:feature}
-  So that ${4:value}  
+  So that ${4:value}
 } do
 end</string>
-	<key>name</key>
-	<string>Story</string>
-	<key>scope</key>
-	<string>source.ruby.rspec</string>
-	<key>tabTrigger</key>
-	<string>st</string>
-	<key>uuid</key>
-	<string>73A67D49-CA5B-4B8A-9B62-003506276CDD</string>
+  <key>name</key>
+  <string>Story</string>
+  <key>scope</key>
+  <string>source.ruby.rspec</string>
+  <key>tabTrigger</key>
+  <string>st</string>
+  <key>uuid</key>
+  <string>73A67D49-CA5B-4B8A-9B62-003506276CDD</string>
 </dict>
 </plist>

--- a/Snippets/context.tmSnippet
+++ b/Snippets/context.tmSnippet
@@ -2,17 +2,17 @@
 <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>content</key>
-	<string>context "${1:description}" do
+  <key>content</key>
+  <string>context '${1:description}' do
   $0
 end</string>
-	<key>name</key>
-	<string>context</string>
-	<key>scope</key>
-	<string>source.ruby.rspec</string>
-	<key>tabTrigger</key>
-	<string>context</string>
-	<key>uuid</key>
-	<string>AD51AA2B-09C9-40DE-9720-2FD43C967FA9</string>
+  <key>name</key>
+  <string>context</string>
+  <key>scope</key>
+  <string>source.ruby.rspec</string>
+  <key>tabTrigger</key>
+  <string>context</string>
+  <key>uuid</key>
+  <string>AD51AA2B-09C9-40DE-9720-2FD43C967FA9</string>
 </dict>
 </plist>

--- a/Snippets/controller_context_RESTful.tmSnippet
+++ b/Snippets/controller_context_RESTful.tmSnippet
@@ -2,17 +2,17 @@
 <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>content</key>
-	<string>describe ${1:controller}, "${2:GET|POST|PUT|DELETE} ${3:/some/path}${4: with some parameters}" do
+  <key>content</key>
+  <string>describe ${1:controller}, '${2:GET|POST|PUT|DELETE} ${3:/some/path}${4: with some parameters}' do
   $0
 end</string>
-	<key>name</key>
-	<string>describe (RESTful Controller)</string>
-	<key>scope</key>
-	<string>source.ruby.rspec</string>
-	<key>tabTrigger</key>
-	<string>desrc</string>
-	<key>uuid</key>
-	<string>0ED99C84-1F7B-471E-BB88-B59C5D08FA6B</string>
+  <key>name</key>
+  <string>describe (RESTful Controller)</string>
+  <key>scope</key>
+  <string>source.ruby.rspec</string>
+  <key>tabTrigger</key>
+  <string>desrc</string>
+  <key>uuid</key>
+  <string>0ED99C84-1F7B-471E-BB88-B59C5D08FA6B</string>
 </dict>
 </plist>

--- a/Snippets/it_should_behave_like.tmSnippet
+++ b/Snippets/it_should_behave_like.tmSnippet
@@ -2,15 +2,15 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>content</key>
-	<string>it_should_behave_like ${2:"$1"}$0</string>
-	<key>name</key>
-	<string>it_should_behave_like</string>
-	<key>scope</key>
-	<string>source.ruby.rspec</string>
-	<key>tabTrigger</key>
-	<string>itsbl</string>
-	<key>uuid</key>
-	<string>D13C48F3-C62B-4456-B075-36B424D573CC</string>
+  <key>content</key>
+  <string>it_should_behave_like ${2:'$1'}$0</string>
+  <key>name</key>
+  <string>it_should_behave_like</string>
+  <key>scope</key>
+  <string>source.ruby.rspec</string>
+  <key>tabTrigger</key>
+  <string>itsbl</string>
+  <key>uuid</key>
+  <string>D13C48F3-C62B-4456-B075-36B424D573CC</string>
 </dict>
 </plist>

--- a/Snippets/mock.tmSnippet
+++ b/Snippets/mock.tmSnippet
@@ -2,15 +2,15 @@
 <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>content</key>
-	<string>${1:var} = mock("${2:mock_name}"${3:, :null_object =&gt; true})$0</string>
-	<key>name</key>
-	<string>mock</string>
-	<key>scope</key>
-	<string>source.ruby.rspec</string>
-	<key>tabTrigger</key>
-	<string>moc</string>
-	<key>uuid</key>
-	<string>AA3D9F87-FE8F-4808-A732-F368CCB9DED6</string>
+  <key>content</key>
+  <string>${1:var} = mock('${2:mock_name}'${3:, :null_object =&gt; true})$0</string>
+  <key>name</key>
+  <string>mock</string>
+  <key>scope</key>
+  <string>source.ruby.rspec</string>
+  <key>tabTrigger</key>
+  <string>moc</string>
+  <key>uuid</key>
+  <string>AA3D9F87-FE8F-4808-A732-F368CCB9DED6</string>
 </dict>
 </plist>


### PR DESCRIPTION
Prefer single-quoted strings when you don't need 
string interpolation or special symbols such as \t, \n, ', etc.

Affected [describe, it, story, context, it_should, mock]

Now context makes 

```
context 'title of ths context' do
    # test something...
end
```

instead of 

```
context "title of ths context" do
    # test something...
end
```

Based on: https://github.com/bbatsov/ruby-style-guide#strings
