### PR TITLE
modernizes spec_helper snippet

### DIFF
--- a/Snippets/Require spec_helper.tmSnippet
+++ b/Snippets/Require spec_helper.tmSnippet
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>content</key>
-	<string>require File.dirname(__FILE__) + '/../spec_helper'</string>
+	<string>require 'spec_helper'</string>
 	<key>name</key>
 	<string>Require spec_helper</string>
 	<key>scope</key>


### PR DESCRIPTION
Tutorials and best-practice guides to RSpec all require the 'spec_helper' in this way.

This allows your spec files to have a nested directory structure, rather than a flat hierarchy to 'spec/'.
