### PR TITLE
Use of single quote for static text in Ruby

### DIFF
--- a/Snippets/Describe_type.tmSnippet
+++ b/Snippets/Describe_type.tmSnippet
@@ -4,7 +4,7 @@
 <dict>
 	<key>content</key>
 	<string>describe ${1:Type} do
-  ${2:it "${3:does something}" do
+  ${2:it '${3:does something}' do
     $0
   end}
 end</string>

--- a/Snippets/Describe_type_string.tmSnippet
+++ b/Snippets/Describe_type_string.tmSnippet
@@ -3,8 +3,8 @@
 <plist version="1.0">
 <dict>
 	<key>content</key>
-	<string>describe ${1:Type}, "${2:description}" do
-  ${3:it "${4:does something}" do
+	<string>describe ${1:Type}, '${2:description}' do
+  ${3:it '${4:does something}' do
     $0
   end}
 end</string>

--- a/Snippets/describe-block.sublime-snippet
+++ b/Snippets/describe-block.sublime-snippet
@@ -1,8 +1,8 @@
 <snippet>
-    <content><![CDATA[describe "${1:description}" do
+    <content><![CDATA[describe '${1:description}' do
   $0
 end]]></content>
     <tabTrigger>des</tabTrigger>
     <scope>source.ruby.rspec</scope>
-    <description>describe "description" do … end</description>
+    <description>describe 'description' do … end</description>
 </snippet>

--- a/Snippets/it-block.sublime-snippet
+++ b/Snippets/it-block.sublime-snippet
@@ -1,8 +1,8 @@
 <snippet>
-    <content><![CDATA[it "${1:does something}" do
+    <content><![CDATA[it '${1:does something}' do
 	$0
 end]]></content>
     <tabTrigger>it</tabTrigger>
     <scope>source.ruby.rspec</scope>
-    <description>it "does something" do … end</description>
+    <description>it 'does something' do … end</description>
 </snippet>


### PR DESCRIPTION
'it', 'describe' and 'context' blocs are generally static text strings.
Since they don't need string interpolations and/or symbols, they shouldn't use double quoted strings.

I tend to use this guide as a reference, because most of Ruby linters / static code analyzers follow it (Rubocop, Puppet Linter, Cane) : https://github.com/bbatsov/ruby-style-guide

Unfortunately there are two different opinions about usage of single/double quoted strings.
None of them is "the officially recognized one" as far as I know.
