### PR TITLE
fix 'let' regex syntax highlight to avoid capturing words like 'letter'

### DIFF
--- a/RSpec.tmLanguage
+++ b/RSpec.tmLanguage
@@ -52,7 +52,7 @@
 	<array>
 		<dict>
 			<key>match</key>
-			<string>(?&lt;!\.)\b(before\b|after\b|subject!?|let!?)</string>
+			<string>(?&lt;!\.)\b(before\b|after\b|subject!?|let!|let(?!\w))</string>
 			<key>name</key>
 			<string>keyword.other.rspec</string>
 		</dict>


### PR DESCRIPTION
I came across what seems to be a bug in the syntax highlight regex. Before this commit this package would not only highlight:

``` rspec
let
let!
```

but also part of words like `letter` 
I have updated the regex to fix the issue. It works but I am not highly proficient in regex so please excuse me if it's not the most elegant form.

Let me know what you see.
