### PR TITLE
Fix quotes for context description

### DIFF
--- a/Snippets/context.sublime-snippet
+++ b/Snippets/context.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
-    <content><![CDATA[context '${1:description}' do
+    <content><![CDATA[context "${1:description}" do
 	$0
 end]]></content>
     <tabTrigger>con</tabTrigger>


### PR DESCRIPTION
`describe` snippet has double quotes for description and `context` single quotes. This change change to use double quotes in both.