### PR TITLE
Add highlighting for rspec-its

### DIFF
--- a/RSpec.tmLanguage
+++ b/RSpec.tmLanguage
@@ -11,7 +11,7 @@
 	    (\s*+
 	        (module|class|def
 	        |background|feature|subscribe
-	        |before|describe|it|scenario
+	        |before|describe|it|its|scenario
 	        |unless|if
 	        |case
 	        |begin
@@ -119,7 +119,7 @@
 		<key>example</key>
 		<dict>
 			<key>begin</key>
-			<string>^\s*(it|specify|scenario)\b</string>
+			<string>^\s*(it|its|specify|scenario)\b</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>
@@ -151,7 +151,7 @@
 		<key>pending</key>
 		<dict>
 			<key>begin</key>
-			<string>^\s*(it|specify|scenario)\b(?=((?!do|{).)*$)</string>
+			<string>^\s*(it|its|specify|scenario)\b(?=((?!do|{).)*$)</string>
 			<key>end</key>
 			<string>$</string>
 			<key>beginCaptures</key>
@@ -183,7 +183,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>^\s*(it|specify|scenario)\s*{</string>
+			<string>^\s*(it|its|specify|scenario)\s*{</string>
 		</dict>
 	</dict>
 	<key>scopeName</key>


### PR DESCRIPTION
Make `its` highlighted the same way as `it`, for use with [rspec-its](https://github.com/rspec/rspec-its)