### PR TITLE
make description match type of quotes used

### DIFF
--- a/Snippets/context.sublime-snippet
+++ b/Snippets/context.sublime-snippet
@@ -4,5 +4,5 @@
 end]]></content>
     <tabTrigger>con</tabTrigger>
     <scope>source.ruby.rspec</scope>
-    <description>context 'description' do … end</description>
+    <description>context "description" do … end</description>
 </snippet>


### PR DESCRIPTION
An old commit had left the description inconsistent with the actual behavior of the snippet. When you saw it as a possible completion, it indicated that it would insert a context block with single quotes, but what actually showed up had double quotes.