### PR TITLE
Add snippet for RSpec 3 one-liner syntax for subject

### DIFF
--- a/Snippets/it-is-expected.sublime-snippet
+++ b/Snippets/it-is-expected.sublime-snippet
@@ -1,0 +1,6 @@
+<snippet>
+    <content><![CDATA[it { ${2:is_expected.to ${1:matcher}} }$0]]></content>
+    <tabTrigger>itie</tabTrigger>
+    <scope>source.ruby.rspec</scope>
+    <description>it { is_expected.to something }</description>
+</snippet>


### PR DESCRIPTION
I added this snippet for the one-liner syntax for setting an expectation on the subject. ([see RSpec docs](https://www.relishapp.com/rspec/rspec-core/docs/subject/one-liner-syntax))

I chose `itie` as the trigger.

```ruby
RSpec.describe Array do
  describe "with 3 items" do
    subject { [1,2,3] }
    it { is_expected.not_to be_empty }
  end
end
```