### PR TITLE
have subject automatically remove brackets and : if no symbol supplied

### DIFF
--- a/Snippets/subject.sublime-snippet
+++ b/Snippets/subject.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
-    <content><![CDATA[subject(:${1:subject}) { ${3:${2:described_class}.new${4:($5)}} }]]></content>
+    <content><![CDATA[subject${1/(^.+$)|^$/(?1:\(\:)/}${1:subject}${1/(^.+$)|^$/(?1:\)/} { ${3:${2:described_class}.new${4:($5)}} }]]></content>
     <tabTrigger>subject</tabTrigger>
     <scope>source.ruby.rspec</scope>
     <description>subject(:subject) { described_class.new }</description>


### PR DESCRIPTION
This introduces a little regex magic so that the `(:)` is removed if no text for the subject name is present. It is inspired by the standard sublime snippet for `do` blocks in ruby.