### PR TITLE
use and_return as default on allow stubs instead of with args

### DIFF
--- a/Snippets/allow-to-receive.sublime-snippet
+++ b/Snippets/allow-to-receive.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
-    <content><![CDATA[allow(${1:collaborator}).to receive(:${2:message})${3:.with(${4:args})}$0]]></content>
+    <content><![CDATA[allow(${1:collaborator}).to receive(:${2:message})${3:.and_return(${4:result})}$0]]></content>
     <tabTrigger>allrec</tabTrigger>
     <scope>source.ruby.rspec</scope>
     <description>allow(object).to receive(message)</description>

--- a/Snippets/allow-to-receive.sublime-snippet
+++ b/Snippets/allow-to-receive.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
-    <content><![CDATA[allow(${1:collaborator}).to receive(:${2:message})${3:.and_return(${4:result})}$0]]></content>
+    <content><![CDATA[allow(${1:collaborator}).to receive(:${2:message})${3:.with(${4:args})}${5:.and_return(${6:result})}$0]]></content>
     <tabTrigger>allrec</tabTrigger>
     <scope>source.ruby.rspec</scope>
     <description>allow(object).to receive(message)</description>


### PR DESCRIPTION
Since `allow` is usually used for stubbing there will almost always be a value to be returned - probably more often than arguments to check. This PR changes the allow snippet reflect that.