### PR TITLE
use single quotes everywhere

### DIFF
--- a/Snippets/Describe_type.tmSnippet
+++ b/Snippets/Describe_type.tmSnippet
@@ -4,7 +4,7 @@
 <dict>
 	<key>content</key>
 	<string>describe ${1:Type} do
-  ${2:it "${3:does something}" do
+  ${2:it '${3:does something}' do
     $0
   end}
 end</string>

--- a/Snippets/Describe_type_string.tmSnippet
+++ b/Snippets/Describe_type_string.tmSnippet
@@ -3,8 +3,8 @@
 <plist version="1.0">
 <dict>
 	<key>content</key>
-	<string>describe ${1:Type}, "${2:description}" do
-  ${3:it "${4:does something}" do
+	<string>describe ${1:Type}, '${2:description}' do
+  ${3:it '${4:does something}' do
     $0
   end}
 end</string>

--- a/Snippets/Story.tmSnippet
+++ b/Snippets/Story.tmSnippet
@@ -3,10 +3,10 @@
 <plist version="1.0">
 <dict>
 	<key>content</key>
-	<string>Story "${1:title}", %{
+	<string>Story '${1:title}', %{
   As a${2:role}
   I want ${3:feature}
-  So that ${4:value}  
+  So that ${4:value}
 } do
 end</string>
 	<key>name</key>

--- a/Snippets/context.sublime-snippet
+++ b/Snippets/context.sublime-snippet
@@ -1,8 +1,8 @@
 <snippet>
-    <content><![CDATA[context "${1:description}" do
+    <content><![CDATA[context '${1:description}' do
 	$0
 end]]></content>
     <tabTrigger>con</tabTrigger>
     <scope>source.ruby.rspec</scope>
-    <description>context "description" do … end</description>
+    <description>context 'description' do … end</description>
 </snippet>

--- a/Snippets/describe-block.sublime-snippet
+++ b/Snippets/describe-block.sublime-snippet
@@ -1,8 +1,8 @@
 <snippet>
-    <content><![CDATA[describe "${1:description}" do
+    <content><![CDATA[describe '${1:description}' do
   $0
 end]]></content>
     <tabTrigger>des</tabTrigger>
     <scope>source.ruby.rspec</scope>
-    <description>describe "description" do … end</description>
+    <description>describe 'description' do … end</description>
 </snippet>

--- a/Snippets/it-block.sublime-snippet
+++ b/Snippets/it-block.sublime-snippet
@@ -1,8 +1,8 @@
 <snippet>
-    <content><![CDATA[it "${1:does something}" do
+    <content><![CDATA[it '${1:does something}' do
 	$0
 end]]></content>
     <tabTrigger>it</tabTrigger>
     <scope>source.ruby.rspec</scope>
-    <description>it "does something" do … end</description>
+    <description>it 'does something' do … end</description>
 </snippet>

--- a/Snippets/it-should-behave-like.sublime-snippet
+++ b/Snippets/it-should-behave-like.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
-    <content><![CDATA[it_should_behave_like ${2:"$1"}$0]]></content>
+    <content><![CDATA[it_should_behave_like ${2:'$1'}$0]]></content>
     <tabTrigger>itsbl</tabTrigger>
     <scope>source.ruby.rspec</scope>
     <description>it_should_behave_like</description>

--- a/Snippets/it_behaves_like.tmSnippet
+++ b/Snippets/it_behaves_like.tmSnippet
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>content</key>
-	<string>it_behaves_like ${2:"$1"}$0</string>
+	<string>it_behaves_like ${2:'$1'}$0</string>
 	<key>name</key>
 	<string>it_behaves_like</string>
 	<key>scope</key>

--- a/Snippets/mock.tmSnippet
+++ b/Snippets/mock.tmSnippet
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>content</key>
-	<string>${1:var} = mock("${2:mock_name}"${3:, :null_object =&gt; true})$0</string>
+	<string>${1:var} = mock('${2:mock_name}'${3:, :null_object =&gt; true})$0</string>
 	<key>name</key>
 	<string>mock</string>
 	<key>scope</key>

--- a/Snippets/pending.sublime-snippet
+++ b/Snippets/pending.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
-    <content><![CDATA[pending${1: "${2:reason}"}]]></content>
+    <content><![CDATA[pending${1: '${2:reason}'}]]></content>
     <tabTrigger>pending</tabTrigger>
     <scope>source.ruby.rspec</scope>
     <description>pending</description>


### PR DESCRIPTION
The use of single vs. double quotes differs right now all over the place. This PR would change that to consistent use of single quotes everywhere.