### PR TITLE
snippets for before(:all) and after(:all)

### DIFF
--- a/Snippets/after_all.sublime-snippet
+++ b/Snippets/after_all.sublime-snippet
@@ -1,0 +1,8 @@
+<snippet>
+    <content><![CDATA[after(:all) do
+  $0
+end]]></content>
+    <tabTrigger>afta</tabTrigger>
+    <scope>source.ruby.rspec</scope>
+    <description>after(:all) do … end</description>
+</snippet>

--- a/Snippets/before_all.sublime-snippet
+++ b/Snippets/before_all.sublime-snippet
@@ -1,0 +1,8 @@
+<snippet>
+    <content><![CDATA[before(:all) do
+  $0
+end]]></content>
+    <tabTrigger>befa</tabTrigger>
+    <scope>source.ruby.rspec</scope>
+    <description>before(:all) do … end</description>
+</snippet>


### PR DESCRIPTION
Using before(:all) and after(:all) is very helpful for speeding up test cases where lots of objects are needed for stateful testing. The existing snippets are inconsistent since `bef` gives you
```
before do
end
```
and `aft` gives you
```
after(:each) do
end
```

Since before == before(:each) which is probably the most common use case, I didn't want to modify that. So I just added `befa` and `afta` to explicitly expand to `before(:all)` and `after(:all)`