### PR TITLE
Add expect to have_content snippet

### DIFF
--- a/Snippets/expect-to-have_content.sublime-snippet
+++ b/Snippets/expect-to-have_content.sublime-snippet
@@ -1,0 +1,6 @@
+<snippet>
+    <content><![CDATA[expect(${1:subject}).to have_content(${2:content})$0]]></content>
+    <tabTrigger>exphc</tabTrigger>
+    <scope>source.ruby.rspec</scope>
+    <description>expect(object).to have_content(content)</description>
+</snippet>


### PR DESCRIPTION
I found it quite useful to have a snippet to trigger `expect(obj).to have_content(cont)` while I was writing RSpec features and unit tests. I needed to write a lot of it. So I added such a snippet.