### PR TITLE
add support for new recommended "context" scope

### DIFF
--- a/Snippets/after_context.sublime-snippet
+++ b/Snippets/after_context.sublime-snippet
@@ -1,0 +1,8 @@
+<snippet>
+  <content><![CDATA[after(:context) do
+  $0
+end]]></content>
+  <tabTrigger>aftc</tabTrigger>
+  <scope>source.ruby.rspec</scope>
+  <description>after(:context) do … end</description>
+</snippet>

--- a/Snippets/before_context.sublime-snippet
+++ b/Snippets/before_context.sublime-snippet
@@ -1,0 +1,8 @@
+<snippet>
+  <content><![CDATA[before(:context) do
+  $0
+end]]></content>
+  <tabTrigger>befc</tabTrigger>
+  <scope>source.ruby.rspec</scope>
+  <description>before(:context) do … end</description>
+</snippet>


### PR DESCRIPTION
With newer versions of RSpec they recommend using `before(:context)` rather than `before(:all)`. Same with `after`.