### PR TITLE
build system: Add syntax

### DIFF
--- a/RSpec (all specs).sublime-build
+++ b/RSpec (all specs).sublime-build
@@ -10,5 +10,6 @@
 	],
 	"selector": "source.ruby",
 	"file_regex": "rspec ([A-Za-z0-9_.\/ ]+rb):([0-9]+) #()(.+)$",
+	"syntax": "Packages/RSpec/RSpec output.sublime-syntax",
 	"working_dir": "${project_path:${folder:${file_path}}}",
 }

--- a/RSpec (open spec).sublime-build
+++ b/RSpec (open spec).sublime-build
@@ -7,5 +7,6 @@
 	],
 	"file_regex": "rspec ([A-Za-z0-9_.\/ ]+rb):([0-9]+) #()(.+)$",
 	"working_dir": "${project_path:${folder:${file_path}}}",
+	"syntax": "Packages/RSpec/RSpec output.sublime-syntax",
 	"selector": "source.ruby.rspec",
 }

--- a/RSpec output.sublime-syntax
+++ b/RSpec output.sublime-syntax
@@ -1,0 +1,15 @@
+%YAML 1.2
+---
+# See http://www.sublimetext.com/docs/syntax.html
+scope: text.build-output.rspec
+version: 2
+hidden: true
+
+contexts:
+  main:
+    - match: "rspec ([A-Za-z0-9_.\/ ]+rb):([0-9]+) #.+$"
+      captures:
+        1: entity.name.filename.build-output
+        2: constant.numeric.line-number.build-output
+    - match: '^\[.+\]$'
+      scope: comment.line.result.build-output

--- a/tests/syntax_test_rspec_output
+++ b/tests/syntax_test_rspec_output
@@ -1,0 +1,14 @@
+# SYNTAX TEST "Packages/RSpec/RSpec output.sublime-syntax"
+
+
+rspec ./spec/myapp/under_test_spec.rb:16 # Foo::Bar #query will return all sorts of things
+#<- -entity.name.filename.build-output
+#^^^^^ -entity.name.filename.build-output
+#     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ entity.name.filename.build-output
+#                                    ^ -entity -constant
+#                                     ^^ constant.numeric.line-number.build-output
+
+
+[Finished in 705ms with exit code 1]
+#<- comment.line.result.build-output
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.result.build-output


### PR DESCRIPTION
I gave up on formatting dots and Fs as RSpec doesn't have an option to block test cases' stdout by default, so its output is mixed with whatever the tests print while they run.

The syntax only highlights build system comments (`[Finished in 253ms]`) and the file names with the same scope as Find in Files and LSP diagnostics. This allows for cool integrations ([example](https://github.com/guille/dotfiles/blob/master/sublime/Plugins/open_file_from_find_results_command.py))